### PR TITLE
fix: deep-merge nested dicts in ConfigDict constructor's *args path

### DIFF
--- a/tinyml-modelmaker/tests/test_config_dict.py
+++ b/tinyml-modelmaker/tests/test_config_dict.py
@@ -44,3 +44,9 @@ class TestConfigDict:
         cfg = ConfigDict(None)
         # Should create an empty config without error
         assert isinstance(cfg, ConfigDict)
+
+    def test_constructor_args_deep_merge_nested_dict(self):
+        default = dict(training=dict(a=1, b=2))
+        user = dict(training=dict(b=99))
+        cfg = ConfigDict(default, user)
+        assert dict(cfg.training) == {"a": 1, "b": 99}

--- a/tinyml-modelmaker/tinyml_modelmaker/utils/config_dict.py
+++ b/tinyml-modelmaker/tinyml_modelmaker/utils/config_dict.py
@@ -57,7 +57,7 @@ class ConfigDict(dict):
         # override the entries with args
         for value in args:
             if isinstance(value, (dict, ConfigDict)):
-                input_dict.update(value)
+                self._deep_merge(input_dict, value)
             #
         #
         # override the entries with kwargs
@@ -94,6 +94,17 @@ class ConfigDict(dict):
 
     def _initialize(self):
         pass
+
+    @staticmethod
+    def _deep_merge(target, source):
+        for key, value in source.items():
+            if key in target and isinstance(target[key], (dict, ConfigDict)) and isinstance(value, (dict, ConfigDict)):
+                ConfigDict._deep_merge(target[key], value)
+            else:
+                target[key] = value
+            #
+        #
+        return target
 
     def _parse_include_files(self, include_files, include_base_path):
         input_dict = {}


### PR DESCRIPTION
## Summary

`ConfigDict`'s constructor merges positional-arg dicts into the base config with a shallow `dict.update()`. A partial override of a nested key (e.g. `training.native_amp`) wholesale-replaces the entire nested dict, silently dropping sibling keys that weren't part of the override (e.g. `training.learning_rate`, `training.batch_size`).

### Root cause

`ConfigDict.__init__`'s `*args` merge loop calls `input_dict.update(value)` directly. `dict.update()` is shallow — for a top-level key whose value is itself a dict, the entire sub-dict is replaced rather than merged. `ConfigDict.update()` (the instance method, used elsewhere) already does a recursive merge; the constructor's `*args` path just didn't match that behavior.

### Fix

Adds a `_deep_merge` static method and uses it in the constructor's `*args` loop instead of `input_dict.update(value)`, matching the recursive-merge semantics `ConfigDict.update()` already provides.

### Verification

Added a regression test (`test_config_dict.py`) that constructs a `ConfigDict` with a default nested dict and a partial override, asserting sibling default keys survive the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)