### PR TITLE
test: fix stale/wrong test assertions and CI trigger gap

### DIFF
--- a/.github/workflows/test-modelmaker.yml
+++ b/.github/workflows/test-modelmaker.yml
@@ -5,11 +5,13 @@ on:
     branches: [platypus_dev_1.3, main]
     paths:
       - 'tinyml-modelmaker/**'
+      - 'tinyml-modelzoo/**'
       - '.github/workflows/test-modelmaker.yml'
   pull_request:
     branches: [platypus_dev_1.3, main]
     paths:
       - 'tinyml-modelmaker/**'
+      - 'tinyml-modelzoo/**'
   workflow_dispatch:  # manual trigger
 
 jobs:

--- a/tinyml-modelmaker/tests/test_config_validation.py
+++ b/tinyml-modelmaker/tests/test_config_validation.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tinyml_modelmaker.ai_modules.audio import training as audio_training
+from tinyml_modelmaker.ai_modules.audio import constants as audio_constants
 from tinyml_modelmaker.ai_modules.timeseries import training, constants
 
 
@@ -38,8 +40,12 @@ def _find_example_configs():
 
 EXAMPLE_CONFIGS = _find_example_configs()
 
-# Known valid task types (timeseries + vision)
-KNOWN_TASK_TYPES = set(constants.TASK_TYPE_TO_CATEGORY.keys()) | {"image_classification"}
+# Known valid task types (timeseries + vision + audio)
+KNOWN_TASK_TYPES = (
+    set(constants.TASK_TYPE_TO_CATEGORY.keys())
+    | set(audio_constants.TASK_TYPES)
+    | {"image_classification"}
+)
 
 # Required top-level keys in every config
 REQUIRED_SECTIONS = {"common", "training"}
@@ -150,7 +156,8 @@ class TestExampleConfigsModelReferences:
         if task_type == "image_classification":
             pytest.skip("Vision model registry not tested here")
 
-        desc = training.get_model_description(model_name)
+        registry = audio_training if task_type in audio_constants.TASK_TYPES else training
+        desc = registry.get_model_description(model_name)
         assert desc is not None, (
             f"Config references model '{model_name}' which is not in the registry"
         )

--- a/tinyml-modelmaker/tests/test_constants.py
+++ b/tinyml-modelmaker/tests/test_constants.py
@@ -92,8 +92,9 @@ class TestGetDefaultDataDir:
             == ts_constants.DATA_DIR_CLASSES
         )
 
-    def test_unknown_category_returns_classes(self):
-        assert ts_constants.get_default_data_dir_for_task("something_else") == ts_constants.DATA_DIR_CLASSES
+    def test_unknown_category_raises(self):
+        with pytest.raises(ValueError, match="Unsupported task_category"):
+            ts_constants.get_default_data_dir_for_task("something_else")
 
     def test_vision_returns_classes(self):
         # Vision module always returns 'classes'

--- a/tinyml-modelmaker/tests/test_cross_device.py
+++ b/tinyml-modelmaker/tests/test_cross_device.py
@@ -355,7 +355,7 @@ class TestQuantizationFlags:
     def test_float_mode_no_normalize(self, task_category):
         """Quantization=0 (float) should set skip_normalize=False, output_int=False."""
         skip, output = constants.get_skip_normalize_and_output_int(
-            task_category, quantization=0, partial_quantization=False
+            task_category, quantization=0, auto_quantization=False
         )
         assert skip is False
         assert output is False
@@ -364,7 +364,7 @@ class TestQuantizationFlags:
         """Classification with quantization should set output_int=True."""
         skip, output = constants.get_skip_normalize_and_output_int(
             constants.TASK_CATEGORY_TS_CLASSIFICATION,
-            quantization=1, partial_quantization=False,
+            quantization=1, auto_quantization=False,
         )
         assert skip is True
         assert output is True
@@ -373,7 +373,7 @@ class TestQuantizationFlags:
         """Regression with quantization should set output_int=False."""
         skip, output = constants.get_skip_normalize_and_output_int(
             constants.TASK_CATEGORY_TS_REGRESSION,
-            quantization=1, partial_quantization=False,
+            quantization=1, auto_quantization=False,
         )
         assert skip is True
         assert output is False
@@ -382,16 +382,16 @@ class TestQuantizationFlags:
         """Forecasting with quantization should set output_int=False."""
         skip, output = constants.get_skip_normalize_and_output_int(
             constants.TASK_CATEGORY_TS_FORECASTING,
-            quantization=1, partial_quantization=False,
+            quantization=1, auto_quantization=False,
         )
         assert skip is True
         assert output is False
 
-    def test_partial_quant_regression_override(self):
-        """Partial quantization for regression should set skip_normalize=False."""
+    def test_auto_quant_regression_override(self):
+        """Auto quantization for regression should set skip_normalize=False."""
         skip, output = constants.get_skip_normalize_and_output_int(
             constants.TASK_CATEGORY_TS_REGRESSION,
-            quantization=1, partial_quantization=True,
+            quantization=1, auto_quantization=True,
         )
         assert skip is False
         assert output is False

--- a/tinyml-modelmaker/tests/test_dataset_utils.py
+++ b/tinyml-modelmaker/tests/test_dataset_utils.py
@@ -58,7 +58,7 @@ class TestCreateInterFileSplit:
         fl = tmp_path / "file_list.txt"
         fl.write_text("a.csv\nb.csv\n")
         split_files = (str(tmp_path / "train.txt"), str(tmp_path / "val.txt"))
-        with pytest.raises(ValueError, match="less than 1"):
+        with pytest.raises(ValueError, match=r"range \(0\.0, 1\.0\)"):
             dataset_utils.create_inter_file_split(str(fl), split_files, 1.5)
 
     def test_split_factor_list_sum_too_large(self, tmp_path):


### PR DESCRIPTION
## Summary

Two independent test/CI hygiene fixes, confirmed unrelated to any production code change (verified via `git stash` — all of the below fail identically on unmodified `main`).

### Stale/wrong test assertions

- `test_config_validation.py`: `KNOWN_TASK_TYPES` and the model-registry check only covered timeseries + vision, so every audio modelzoo example (`task_type='audio_classification'`, e.g. `DSCNN_NPU`) looked invalid. Includes the audio module's task types and routes audio configs to its own model registry.
- `test_constants.py`: `get_default_data_dir_for_task()` now raises `ValueError` on unknown categories, but the test still asserted the old silent `DATA_DIR_CLASSES` fallback. Updated to match current behavior.
- `test_cross_device.py`: `TestQuantizationFlags` called `get_skip_normalize_and_output_int(..., partial_quantization=...)`, but the real parameter is `auto_quantization` — a wrong kwarg name, not a real API. Renamed calls; the one test that was actually about `auto_quantization` semantics is kept meaningful.
- `test_dataset_utils.py`: `test_split_factor_too_large` matched a stale error-message regex (`"less than 1"`) against the current message (`"must be in the range (0.0, 1.0)"`); behavior was already correct, only the assertion was stale.

**One gap found and left open, not guessed at:** `F28E12` is listed in `TARGET_DEVICES` but has no entry in `_DEVICE_PROFILES`, so `test_cross_device.py::TestCompilationProfileCorrectness` still fails for it (5 tests). This needs real hardware values (`cross_compiler` path, `target`, `target_c_mcpu`, `has_hard_npu`) that aren't safe to fabricate — flagging it here rather than papering over it with placeholder values.

### CI trigger gap

`tinyml-modelmaker` depends on `tinyml-modelzoo` (`pip install -e tinyml-modelzoo` in the `Install dependencies` step), but dependency-only changes to `tinyml-modelzoo` wouldn't trigger the test suite at all. Adds the missing path trigger.

**Note:** this touches `.github/workflows/test-modelmaker.yml`, which two of my other open PRs (`pr/dataloader-pinning-fix`, `pr/mps-eval-fixes`) also touch — each adds one path-trigger line at the same position. If merged after either, GitHub will show a trivial 3-line conflict; the correct resolution is just keeping all the added lines (a union), not choosing one over the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)