### PR TITLE
fix: str2int_or_float's float branch was unreachable dead code

### DIFF
--- a/tinyml-tinyverse/tests/test_str2int_or_float.py
+++ b/tinyml-tinyverse/tests/test_str2int_or_float.py
@@ -1,0 +1,39 @@
+"""Regression test for str2int_or_float()'s unreachable float branch.
+
+not v.isdigit() is True for any string containing '.' (e.g. '31.25') or a
+leading '-', so checking it before the '.' in v branch made float conversion
+dead code -- every float-like string fell through to the string passthrough
+instead of being converted, silently breaking any caller (e.g. Downsample())
+that does arithmetic assuming a numeric type.
+"""
+from tinyml_tinyverse.common.utils.misc_utils import str2int_or_float
+
+
+def test_str2int_or_float_converts_fractional_strings():
+    assert str2int_or_float("31.25") == 31.25
+    assert isinstance(str2int_or_float("31.25"), float)
+
+
+def test_str2int_or_float_converts_plain_integer_strings():
+    assert str2int_or_float("42") == 42
+    assert isinstance(str2int_or_float("42"), int)
+
+
+def test_str2int_or_float_passes_through_non_numeric_strings():
+    assert str2int_or_float("abc") == "abc"
+
+
+def test_str2int_or_float_passes_through_non_numeric_strings_with_a_dot():
+    assert str2int_or_float("abc.def") == "abc.def"
+
+
+def test_str2int_or_float_handles_special_string_sentinels():
+    assert str2int_or_float("None") is None
+    assert str2int_or_float("True") is True
+    assert str2int_or_float("False") is False
+
+
+def test_str2int_or_float_passes_through_non_string_values():
+    assert str2int_or_float(5) == 5
+    assert str2int_or_float(5.5) == 5.5
+    assert str2int_or_float(None) is None

--- a/tinyml-tinyverse/tinyml_tinyverse/common/utils/misc_utils.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/utils/misc_utils.py
@@ -88,12 +88,19 @@ def str2int_or_float(v):
             return False
         elif v == 'True':
             return True
-        elif not v.isdigit():
-            return str(v)
         elif '.' in v:
-            return float(v)
-        else:
+            # Must be checked before isdigit(): isdigit() is False for any string
+            # containing '.' (e.g. '31.25'), so checking it first made this branch
+            # unreachable -- every float-like string fell through to the
+            # not-isdigit() string passthrough below instead of being converted.
+            try:
+                return float(v)
+            except ValueError:
+                return v
+        elif v.isdigit():
             return int(v)
+        else:
+            return v
     else:
         return v
 


### PR DESCRIPTION
## Summary

`str2int_or_float()` coerces every kwarg passed into `BaseGenericTSDataset` (used throughout `timeseries_dataset.py`). Its float-conversion branch was unreachable dead code.

### Root cause

```python
elif not v.isdigit():
    return str(v)
elif '.' in v:
    return float(v)
```

`str.isdigit()` is `False` for any string containing a `.` (e.g. `'31.25'`) or a leading `-`, so the `not v.isdigit()` branch always fires first and returns the value unconverted as a string — the `'.' in v: return float(v)` branch could never execute.

### Concrete impact

A fractional `--sampling-rate`/`--new-sr` (common for IMU/vibration sensor datasets) arriving as an unconverted string crashes `Downsample()` — `common/transforms/basic_transforms.py` does `x[ax][::int(sampling_rate//new_sr)]`, and `str // str` raises `TypeError: unsupported operand type(s) for //: 'str' and 'str'`. There's already a defensive workaround comment elsewhere in `timeseries_dataset.py` (`sr = float(self.sampling_rate)  # handles "31.25" safely`), confirming this exact scenario was hit before — but only one call site was patched; `Downsample()` itself remained unguarded.

### Fix

Reorder the checks: test `'.' in v` before `isdigit()`, so float-like strings route to `float(v)`, with a `ValueError` fallback to the original string passthrough for genuinely non-numeric values like `'abc.def'`.

### Verification

Confirmed the added test for fractional-string conversion fails on the current code (`assert '31.25' == 31.25` — string, not float) and passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)