### PR TITLE
fix: unsafe yaml.CLoader loading in dataset/config parsing

### DIFF
--- a/tinyml-tinyverse/tests/test_timeseries_dataset_augment_config_yaml_error.py
+++ b/tinyml-tinyverse/tests/test_timeseries_dataset_augment_config_yaml_error.py
@@ -41,3 +41,17 @@ def test_augment_config_empty_yaml_does_not_crash():
         dataset = _make_dataset(yaml_path)
 
     assert dataset.augment_pipeline == []
+
+
+def test_augment_config_non_mapping_root_does_not_crash():
+    """Valid YAML whose root is a list (or scalar) parses fine but would
+    crash the `.items()` call that builds the pipeline -- must degrade to
+    no augmenters instead."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yaml_path = os.path.join(tmp_dir, "list_root.yaml")
+        with open(yaml_path, "w") as fp:
+            fp.write("- AddNoise\n- Crop\n")
+
+        dataset = _make_dataset(yaml_path)
+
+    assert dataset.augment_pipeline == []

--- a/tinyml-tinyverse/tests/test_timeseries_dataset_augment_config_yaml_error.py
+++ b/tinyml-tinyverse/tests/test_timeseries_dataset_augment_config_yaml_error.py
@@ -1,0 +1,43 @@
+"""Regression test for a crash the yaml.safe_load() fix (PR #26) exposed in
+BaseGenericTSDataset.__init__ (timeseries_dataset.py).
+
+The try/except around parsing augment_config caught yaml.YAMLError and logged
+it, but never assigned augment_config in the except branch, then
+unconditionally fell through to `augment_config.items()` right after the
+try/except -- raising UnboundLocalError for any YAML that fails to parse
+(e.g. a malicious !!python/object/apply: tag, which safe_load correctly
+refuses via ConstructorError -- a YAMLError subclass). An empty YAML file hit
+the same crash a different way: safe_load() returns None on empty input, so
+`None.items()` raised AttributeError. Both are now handled: the except
+branch sets augment_config = {} on a parse error, and `or {}` covers the
+None-on-empty-file case.
+"""
+import os
+import tempfile
+
+from tinyml_tinyverse.common.datasets.timeseries_dataset import BaseGenericTSDataset
+
+
+def _make_dataset(yaml_path):
+    return BaseGenericTSDataset(subset=None, dataset_dir="/unused", augment_config=yaml_path, transforms=[])
+
+
+def test_augment_config_yaml_error_does_not_crash():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yaml_path = os.path.join(tmp_dir, "malicious.yaml")
+        with open(yaml_path, "w") as fp:
+            fp.write("payload: !!python/object/apply:builtins.print [UNSAFE]\n")
+
+        dataset = _make_dataset(yaml_path)
+
+    assert dataset.augment_pipeline == []
+
+
+def test_augment_config_empty_yaml_does_not_crash():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yaml_path = os.path.join(tmp_dir, "empty.yaml")
+        open(yaml_path, "w").close()
+
+        dataset = _make_dataset(yaml_path)
+
+    assert dataset.augment_pipeline == []

--- a/tinyml-tinyverse/tests/test_yaml_unsafe_loading.py
+++ b/tinyml-tinyverse/tests/test_yaml_unsafe_loading.py
@@ -1,0 +1,44 @@
+"""Regression test for unsafe yaml.CLoader usage.
+
+yaml.CLoader is the C-accelerated equivalent of the unsafe yaml.Loader (not
+yaml.SafeLoader) -- it can instantiate arbitrary Python objects (and execute
+code) via !!python/object/apply:... tags. mdcl_utils.read_yaml_file(),
+image_dataset.py, and timeseries_dataset.py all used it to parse config files.
+This test covers the standalone, directly-testable call site
+(mdcl_utils.read_yaml_file); the dataset-class call sites use the identical
+one-line substitution (yaml.load(Loader=yaml.CLoader) -> yaml.safe_load) and
+were verified by code review rather than duplicating this test against the
+much heavier Dataset class fixtures.
+"""
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from tinyml_tinyverse.common.utils.mdcl_utils import read_yaml_file
+
+
+def test_read_yaml_file_parses_normal_yaml():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yaml_path = os.path.join(tmp_dir, "config.yaml")
+        with open(yaml_path, "w") as fp:
+            fp.write("key: value\nnested:\n  a: 1\n  b: 2\n")
+
+        data = read_yaml_file(yaml_path)
+
+    assert data == {"key": "value", "nested": {"a": 1, "b": 2}}
+
+
+def test_read_yaml_file_rejects_unsafe_python_object_tags(capsys):
+    """A malicious config using !!python/object/apply: would execute arbitrary
+    code under the unsafe Loader; safe_load must refuse to construct it."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yaml_path = os.path.join(tmp_dir, "malicious.yaml")
+        with open(yaml_path, "w") as fp:
+            fp.write("payload: !!python/object/apply:builtins.print [UNSAFE DESERIALIZATION EXECUTED]\n")
+
+        with pytest.raises(yaml.constructor.ConstructorError):
+            read_yaml_file(yaml_path)
+
+    assert "UNSAFE DESERIALIZATION EXECUTED" not in capsys.readouterr().out

--- a/tinyml-tinyverse/tinyml_tinyverse/common/datasets/image_dataset.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/datasets/image_dataset.py
@@ -207,9 +207,6 @@ class GenericImageDataset(Dataset):
                 self.logger.info(f"Parsing {self.augment_config} to form augmentation pipeline")
                 try:
                     with open(self.augment_config) as fp:
-                        # yaml.CLoader is the C-accelerated equivalent of the unsafe
-                        # yaml.Loader (not yaml.SafeLoader) -- it can instantiate
-                        # arbitrary Python objects via !!python/object/apply:... tags.
                         augment_config = yaml.safe_load(fp)
                     self.augment_pipeline = augment_config
                     # Unlike BaseGenericTSDataset (timeseries_dataset.py), there is no

--- a/tinyml-tinyverse/tinyml_tinyverse/common/datasets/image_dataset.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/datasets/image_dataset.py
@@ -207,8 +207,24 @@ class GenericImageDataset(Dataset):
                 self.logger.info(f"Parsing {self.augment_config} to form augmentation pipeline")
                 try:
                     with open(self.augment_config) as fp:
-                        augment_config = yaml.load(fp, Loader=yaml.CLoader)
+                        # yaml.CLoader is the C-accelerated equivalent of the unsafe
+                        # yaml.Loader (not yaml.SafeLoader) -- it can instantiate
+                        # arbitrary Python objects via !!python/object/apply:... tags.
+                        augment_config = yaml.safe_load(fp)
                     self.augment_pipeline = augment_config
+                    # Unlike BaseGenericTSDataset (timeseries_dataset.py), there is no
+                    # augmenter dispatch table for image data -- create_augmenter() only
+                    # knows timeseries-specific augmenters (AddNoise, Crop, TimeWarp,
+                    # etc.), which don't apply to image tensors. self.augment_pipeline is
+                    # therefore never consumed anywhere in this class; parsing succeeds
+                    # but the requested augmentation is silently never applied. Fail loud
+                    # instead of silently ignoring a config the user explicitly set.
+                    self.logger.warning(
+                        f"augment_config ({self.augment_config}) was parsed but image "
+                        "dataset augmentation via augment_config is not implemented -- "
+                        "it will NOT be applied. Use the 'augmentation_transform' "
+                        "parameter instead."
+                    )
                 except yaml.YAMLError as exc:
                     self.logger.critical(f"{exc} error parsing {self.augment_config}")
 

--- a/tinyml-tinyverse/tinyml_tinyverse/common/datasets/timeseries_dataset.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/datasets/timeseries_dataset.py
@@ -118,9 +118,18 @@ class BaseGenericTSDataset(Dataset):
                 self.logger.info(f"Parsing {self.augment_config} to form Augmentation Pipeline")
                 try:
                     with open(self.augment_config) as fp:
-                        augment_config = yaml.safe_load(fp) or {}
+                        augment_config = yaml.safe_load(fp)
                 except yaml.YAMLError as exc:
                     self.logger.critical(f"{exc} error parsing {self.augment_config}")
+                    augment_config = None
+                if augment_config is None:
+                    augment_config = {}
+                elif not isinstance(augment_config, dict):
+                    # A list/scalar root would crash .items() below.
+                    self.logger.critical(
+                        f"{self.augment_config} must contain a YAML mapping of "
+                        f"augmenter-name -> params, got {type(augment_config).__name__}; "
+                        "ignoring it.")
                     augment_config = {}
                 # Create a pipeline of augmenters
                 self.augment_pipeline = [create_augmenter(name, params) for name, params in augment_config.items()]

--- a/tinyml-tinyverse/tinyml_tinyverse/common/datasets/timeseries_dataset.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/datasets/timeseries_dataset.py
@@ -118,7 +118,10 @@ class BaseGenericTSDataset(Dataset):
                 self.logger.info(f"Parsing {self.augment_config} to form Augmentation Pipeline")
                 try:
                     with open(self.augment_config) as fp:
-                        augment_config = yaml.load(fp, Loader=yaml.CLoader)
+                        # yaml.CLoader is the C-accelerated equivalent of the unsafe
+                        # yaml.Loader (not yaml.SafeLoader) -- it can instantiate
+                        # arbitrary Python objects via !!python/object/apply:... tags.
+                        augment_config = yaml.safe_load(fp)
                 except yaml.YAMLError as exc:
                     self.logger.critical(f"{exc} error parsing {self.augment_config}")
                 # Create a pipeline of augmenters

--- a/tinyml-tinyverse/tinyml_tinyverse/common/datasets/timeseries_dataset.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/datasets/timeseries_dataset.py
@@ -118,12 +118,10 @@ class BaseGenericTSDataset(Dataset):
                 self.logger.info(f"Parsing {self.augment_config} to form Augmentation Pipeline")
                 try:
                     with open(self.augment_config) as fp:
-                        # yaml.CLoader is the C-accelerated equivalent of the unsafe
-                        # yaml.Loader (not yaml.SafeLoader) -- it can instantiate
-                        # arbitrary Python objects via !!python/object/apply:... tags.
-                        augment_config = yaml.safe_load(fp)
+                        augment_config = yaml.safe_load(fp) or {}
                 except yaml.YAMLError as exc:
                     self.logger.critical(f"{exc} error parsing {self.augment_config}")
+                    augment_config = {}
                 # Create a pipeline of augmenters
                 self.augment_pipeline = [create_augmenter(name, params) for name, params in augment_config.items()]
 

--- a/tinyml-tinyverse/tinyml_tinyverse/common/utils/mdcl_utils.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/common/utils/mdcl_utils.py
@@ -242,7 +242,10 @@ def read_yaml_file(my_file, log_name='root.utils.RYML'):
         log.error("file/dir path does not exist : {}".format(str(my_file)))
         return
     with open(my_file, 'r') as fp:
-        read_data = yaml.load(fp, Loader=yaml.CLoader)
+        # yaml.CLoader is the C-accelerated equivalent of the unsafe yaml.Loader
+        # (not yaml.SafeLoader) -- it can instantiate arbitrary Python objects via
+        # !!python/object/apply:... tags. safe_load() uses SafeLoader instead.
+        read_data = yaml.safe_load(fp)
     return read_data
 
 


### PR DESCRIPTION
## Summary

`yaml.CLoader` is the C-accelerated equivalent of the unsafe `yaml.Loader` (not `yaml.SafeLoader`) — it can instantiate arbitrary Python objects, and execute code, via `!!python/object/apply:...` tags in the YAML. Used in three places to parse user-supplied config:

- `mdcl_utils.read_yaml_file()` — generic config loading
- `augment_config` parsing in `image_dataset.py`
- `augment_config` parsing in `timeseries_dataset.py`

### Fix

Switched all three to `yaml.safe_load()`.

### Verification

Directly against `mdcl_utils.read_yaml_file()`: confirmed a malicious payload's code genuinely executes under the old loader (captured via stdout — `!!python/object/apply:builtins.print [...]` actually runs) and is correctly rejected with `ConstructorError` after the fix. The two dataset-class call sites use the identical one-line substitution and were verified by code review rather than duplicating the test against much heavier `Dataset` class fixtures.

### Also found while fixing `image_dataset.py`'s call site

`self.augment_pipeline` was being set from the parsed YAML but never actually consumed anywhere in the class — unlike `timeseries_dataset.py`, which builds real augmenter objects via `create_augmenter()` and applies them via `apply_augmenters()`. Image data has no equivalent augmenter dispatch table (`create_augmenter()` only knows timeseries-specific augmenters like `AddNoise`/`Crop`/`TimeWarp`, which don't apply to image tensors), so a user configuring `augment_config` for an image dataset got no error and no augmentation — silently degraded training with no signal the feature isn't wired up.

Rather than inventing a new image-augmentation mechanism (real feature work, out of scope for this fix), made the gap loud instead: a warning now fires stating `augment_config` was parsed but is not applied for image datasets, pointing at the parameter that actually works (`augmentation_transform`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)