### PR TITLE
fix: compilation orchestrator loses cwd and can corrupt model file on failure

### DIFF
--- a/tinyml-tinyverse/tests/test_compilation_orchestrator_bugs.py
+++ b/tinyml-tinyverse/tests/test_compilation_orchestrator_bugs.py
@@ -63,19 +63,24 @@ def _minimal_main_args(tmp_path, generic_model):
     )
 
 
-def test_main_does_not_encrypt_when_decrypt_failed(tmp_path):
-    """A failed decrypt() must not be followed by an encrypt() -- the file was
-    never actually decrypted, so re-encrypting it would corrupt it."""
+def test_main_aborts_without_encrypting_when_decrypt_failed(tmp_path):
+    """A failed decrypt() must not be followed by an encrypt() (the file was
+    never actually decrypted, so re-encrypting it would corrupt it), must not
+    proceed into gen_artifacts() (compiling the still-encrypted blob can only
+    produce garbage), and must report failure via a nonzero exit flag --
+    matching the contract the modelmaker runners consume
+    (exit_flag = compile_scr.run(args))."""
     args = _minimal_main_args(tmp_path, generic_model=False)
 
     with patch.object(compilation.utils, "decrypt", side_effect=RuntimeError("bad key")), \
          patch.object(compilation.utils, "encrypt") as mock_encrypt, \
          patch.object(compilation.utils, "get_crypt_key", return_value="key"), \
-         patch.object(compilation, "gen_artifacts"), \
+         patch.object(compilation, "gen_artifacts") as mock_gen_artifacts, \
          patch.object(compilation, "remove_intermittent_files"):
-        compilation.main(args)
+        assert compilation.main(args) == 1
 
     mock_encrypt.assert_not_called()
+    mock_gen_artifacts.assert_not_called()
 
 
 def test_main_encrypts_after_successful_decrypt_and_successful_compile(tmp_path):

--- a/tinyml-tinyverse/tests/test_compilation_orchestrator_bugs.py
+++ b/tinyml-tinyverse/tests/test_compilation_orchestrator_bugs.py
@@ -1,0 +1,109 @@
+"""Regression tests for two bugs in the compilation orchestrator (compilation.py).
+
+1. gen_artifacts() changed the process cwd to args.output_dir but only restored
+   it on the success path, not in a finally -- a compile failure left the whole
+   (in-process, not subprocess) orchestrator's cwd permanently pointed at
+   args.output_dir for the rest of its lifetime.
+2. main() silently swallowed a failed decrypt() and proceeded as if it had
+   succeeded, then unconditionally re-encrypted args.FILE regardless of whether
+   it had actually been decrypted -- corrupting an already-encrypted file via
+   double-encryption.
+"""
+import os
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from tinyml_tinyverse.references.common import compilation
+
+
+def test_gen_artifacts_restores_cwd_even_when_drive_compile_raises(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "artifacts").mkdir()
+    original_cwd = os.getcwd()
+
+    args = Namespace(output_dir=str(output_dir), output="model", keep_libc_files=True)
+
+    with patch.object(compilation, "drive_compile", side_effect=RuntimeError("TVM blew up")):
+        with pytest.raises(RuntimeError, match="TVM blew up"):
+            compilation.gen_artifacts(args)
+
+    assert os.getcwd() == original_cwd
+
+
+def test_gen_artifacts_restores_cwd_on_success(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "artifacts").mkdir()
+    original_cwd = os.getcwd()
+
+    args = Namespace(output_dir=str(output_dir), output="model", keep_libc_files=True)
+
+    with patch.object(compilation, "drive_compile"):
+        compilation.gen_artifacts(args)
+
+    assert os.getcwd() == original_cwd
+
+
+def _minimal_main_args(tmp_path, generic_model):
+    return Namespace(
+        lis=None,
+        output_dir=str(tmp_path),
+        DEBUG=False,
+        target="c",
+        cross_compiler=str(tmp_path),  # any existing path passes the validation check
+        cross_compiler_options="",
+        target_cmsis_nn_mcpu="None",
+        target_cmsis_nn_mattr="None",
+        generic_model=generic_model,
+        FILE="model.onnx",
+        keep_intermittent_files=True,
+    )
+
+
+def test_main_does_not_encrypt_when_decrypt_failed(tmp_path):
+    """A failed decrypt() must not be followed by an encrypt() -- the file was
+    never actually decrypted, so re-encrypting it would corrupt it."""
+    args = _minimal_main_args(tmp_path, generic_model=False)
+
+    with patch.object(compilation.utils, "decrypt", side_effect=RuntimeError("bad key")), \
+         patch.object(compilation.utils, "encrypt") as mock_encrypt, \
+         patch.object(compilation.utils, "get_crypt_key", return_value="key"), \
+         patch.object(compilation, "gen_artifacts"), \
+         patch.object(compilation, "remove_intermittent_files"):
+        compilation.main(args)
+
+    mock_encrypt.assert_not_called()
+
+
+def test_main_encrypts_after_successful_decrypt_and_successful_compile(tmp_path):
+    """Regression safety: the normal success path must still encrypt exactly once."""
+    args = _minimal_main_args(tmp_path, generic_model=False)
+
+    with patch.object(compilation.utils, "decrypt"), \
+         patch.object(compilation.utils, "encrypt") as mock_encrypt, \
+         patch.object(compilation.utils, "get_crypt_key", return_value="key"), \
+         patch.object(compilation, "gen_artifacts"), \
+         patch.object(compilation, "remove_intermittent_files"):
+        compilation.main(args)
+
+    mock_encrypt.assert_called_once_with("model.onnx", "key")
+
+
+def test_main_encrypts_after_successful_decrypt_even_if_compile_fails(tmp_path):
+    """Regression safety: if decrypt succeeded, the file must be re-encrypted
+    even when gen_artifacts() itself fails (matches the original try/except's
+    intent), and the original exception must still propagate."""
+    args = _minimal_main_args(tmp_path, generic_model=False)
+
+    with patch.object(compilation.utils, "decrypt"), \
+         patch.object(compilation.utils, "encrypt") as mock_encrypt, \
+         patch.object(compilation.utils, "get_crypt_key", return_value="key"), \
+         patch.object(compilation, "gen_artifacts", side_effect=RuntimeError("compile failed")), \
+         patch.object(compilation, "remove_intermittent_files"):
+        with pytest.raises(RuntimeError, match="compile failed"):
+            compilation.main(args)
+
+    mock_encrypt.assert_called_once_with("model.onnx", "key")

--- a/tinyml-tinyverse/tinyml_tinyverse/references/common/compilation.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/references/common/compilation.py
@@ -118,10 +118,14 @@ def gen_artifacts(args):
     try:
         logger.info("Calling TVM to generate artifacts: ")
         drive_compile(Namespace(**input_args))
-    except Exception:
-        raise
-    logger.info("Changing directory back to: {}".format(curr_dir))
-    os.chdir(curr_dir)
+    finally:
+        # Must restore cwd even on failure -- this runs in-process inside the
+        # training orchestrator (called from tinyml_benchmark.py), not a
+        # subprocess, so a compile failure previously left the whole process's
+        # cwd pointed at args.output_dir for the rest of its lifetime, breaking
+        # every subsequent relative-path default elsewhere in the pipeline.
+        logger.info("Changing directory back to: {}".format(curr_dir))
+        os.chdir(curr_dir)
     # We also need to delete the devc.o file as it is not required
     try:
         os.remove(os.path.join(artifacts_dir, 'devc.o'))
@@ -225,19 +229,27 @@ def main(args):
     args.target_example_target_hook_target_device_type = None
     args.target_cmsis_nn_mcpu = None if args.target_cmsis_nn_mcpu=='None' else args.target_cmsis_nn_mcpu
     args.target_cmsis_nn_mattr = None if args.target_cmsis_nn_mattr == 'None' else args.target_cmsis_nn_mattr
+    # Track whether decryption actually succeeded -- previously a failed decrypt()
+    # was silently swallowed and execution proceeded as if it had worked, so
+    # gen_artifacts() would fail confusingly against the still-encrypted file, and
+    # either outcome unconditionally re-encrypted args.FILE regardless of whether
+    # it had ever actually been decrypted, permanently corrupting it via
+    # double-encryption. Only encrypt back if we genuinely decrypted first.
+    decrypted = False
     if not args.generic_model:
         try:
             utils.decrypt(args.FILE, utils.get_crypt_key())
-        except Exception:
-            pass
+            decrypted = True
+        except Exception as exc:
+            logger.error(
+                f"Could not decrypt {args.FILE}: {exc}. "
+                "Compilation will likely fail against the still-encrypted file."
+            )
     try:
         gen_artifacts(args)
-    except Exception:
-        if not args.generic_model:
+    finally:
+        if decrypted:
             utils.encrypt(args.FILE, utils.get_crypt_key())
-        raise
-    if not args.generic_model:
-        utils.encrypt(args.FILE, utils.get_crypt_key())
 
     if not args.keep_intermittent_files:
         remove_intermittent_files(args.output_dir)

--- a/tinyml-tinyverse/tinyml_tinyverse/references/common/compilation.py
+++ b/tinyml-tinyverse/tinyml_tinyverse/references/common/compilation.py
@@ -234,17 +234,17 @@ def main(args):
     # gen_artifacts() would fail confusingly against the still-encrypted file, and
     # either outcome unconditionally re-encrypted args.FILE regardless of whether
     # it had ever actually been decrypted, permanently corrupting it via
-    # double-encryption. Only encrypt back if we genuinely decrypted first.
+    # double-encryption. Only encrypt back if we genuinely decrypted first, and
+    # abort before gen_artifacts() on failure -- compiling the still-encrypted
+    # blob can only produce garbage or a confusing downstream error.
     decrypted = False
     if not args.generic_model:
         try:
             utils.decrypt(args.FILE, utils.get_crypt_key())
             decrypted = True
         except Exception as exc:
-            logger.error(
-                f"Could not decrypt {args.FILE}: {exc}. "
-                "Compilation will likely fail against the still-encrypted file."
-            )
+            logger.error(f"Could not decrypt {args.FILE}: {exc}. Compilation cannot continue.")
+            return 1
     try:
         gen_artifacts(args)
     finally:


### PR DESCRIPTION
## Summary

Two bugs in the compilation orchestrator (`compilation.py`), both in failure-path handling.

### `os.chdir()` never restored on compile failure

```python
curr_dir = os.getcwd()
os.chdir(args.output_dir)
try:
    drive_compile(Namespace(**input_args))
except Exception:
    raise                      # exits without restoring cwd
os.chdir(curr_dir)             # never reached on failure
```

`gen_artifacts()`/`main()` run **in-process** (not a subprocess) inside the training orchestrator, called from `tinyml_benchmark.py`. The file's own comment acknowledges compile failures are common ("compiler/sdk paths provided are invalid"). Any such failure previously left the whole process's cwd pointed at `args.output_dir` for the rest of its lifetime — breaking every subsequent relative-path default elsewhere in the pipeline.

Fixed with `try/finally` so cwd is always restored, on both the success and failure paths.

### Swallowed decrypt failure can silently double-encrypt (corrupt) the model file

```python
if not args.generic_model:
    try:
        utils.decrypt(args.FILE, utils.get_crypt_key())
    except Exception:
        pass                                    # decrypt failure silently swallowed
try:
    gen_artifacts(args)
except Exception:
    if not args.generic_model:
        utils.encrypt(args.FILE, utils.get_crypt_key())   # re-encrypts a file that was NEVER decrypted
    raise
```

If `decrypt()` fails (wrong key, corrupt/locked file), the file on disk is left untouched (still encrypted), but the code proceeds as if decryption succeeded. `gen_artifacts` then fails against the still-encrypted "model" with a confusing low-level TVM/ONNX-parse error instead of the real root cause — and *either* outcome (`gen_artifacts` succeeding or raising) unconditionally re-encrypted `args.FILE`, permanently corrupting it via double-encryption.

Fixed by tracking whether decrypt genuinely succeeded, logging the failure instead of swallowing it, and only re-encrypting if it did.

### Verification

Tests mock `drive_compile`/`decrypt`/`encrypt` (no real TVM compilation or real encrypted files needed). Both target tests reproduce their bug reliably pre-fix and pass post-fix — notably, the cwd bug's pre-fix failure mode was visibly self-cascading: leaving the process directory corrupted broke the *next* test in the same run too, a concrete demonstration of the real severity. Regression-safety tests confirm the normal success path (decrypt OK, compile OK) still encrypts exactly once, and a compile failure after a successful decrypt still re-encrypts and still propagates the original exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)