### PR TITLE
fix: CI never ran tests for 3 of 4 packages, or even triggered on them

### DIFF
--- a/.github/workflows/test-modelmaker.yml
+++ b/.github/workflows/test-modelmaker.yml
@@ -94,7 +94,7 @@ jobs:
       - name: tinyml-tinyverse Tests
         working-directory: tinyml-tinyverse
         run: |
-          if [ -d tests ] && find tests -name 'test_*.py' -print -quit | grep -q .; then
+          if [ -d tests ] && find tests \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit | grep -q .; then
             python -m pytest tests/ -v --tb=short
           else
             echo "No tests found in tinyml-tinyverse/tests/ yet -- skipping."
@@ -103,7 +103,7 @@ jobs:
       - name: tinyml-modelzoo Tests
         working-directory: tinyml-modelzoo
         run: |
-          if [ -d tests ] && find tests -name 'test_*.py' -print -quit | grep -q .; then
+          if [ -d tests ] && find tests \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit | grep -q .; then
             python -m pytest tests/ -v --tb=short
           else
             echo "No tests found in tinyml-modelzoo/tests/ yet -- skipping."
@@ -112,7 +112,7 @@ jobs:
       - name: torchmodelopt — Component Tests
         working-directory: tinyml-modeloptimization/torchmodelopt
         run: |
-          if [ -d tests ] && find tests -name 'test_*.py' -print -quit | grep -q .; then
+          if [ -d tests ] && find tests \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit | grep -q .; then
             python -m pytest tests/ -v --tb=short
           else
             echo "No tests found in tinyml-modeloptimization/torchmodelopt/tests/ yet -- skipping."

--- a/.github/workflows/test-modelmaker.yml
+++ b/.github/workflows/test-modelmaker.yml
@@ -5,11 +5,17 @@ on:
     branches: [platypus_dev_1.3, main]
     paths:
       - 'tinyml-modelmaker/**'
+      - 'tinyml-tinyverse/**'
+      - 'tinyml-modelzoo/**'
+      - 'tinyml-modeloptimization/**'
       - '.github/workflows/test-modelmaker.yml'
   pull_request:
     branches: [platypus_dev_1.3, main]
     paths:
       - 'tinyml-modelmaker/**'
+      - 'tinyml-tinyverse/**'
+      - 'tinyml-modelzoo/**'
+      - 'tinyml-modeloptimization/**'
   workflow_dispatch:  # manual trigger
 
 jobs:
@@ -73,3 +79,38 @@ jobs:
       - name: Tier 2 — Pipeline Smoke Tests
         working-directory: tinyml-modelmaker
         run: python -m pytest tests/test_pipeline_smoke.py -v --tb=short
+
+      # tinyml-tinyverse, tinyml-modelzoo, and torchmodelopt have no
+      # equivalent of the Tier steps above -- until now, nothing ran their
+      # tests/ directories in CI at all, so every regression test added
+      # there was silently never checked on push/PR. Guarded with a
+      # find-based existence check (rather than a plain `test -d tests`)
+      # since an empty tests/ directory makes pytest exit non-zero with "no
+      # tests collected", which would otherwise fail CI on packages that
+      # temporarily have no tests.
+      - name: tinyml-tinyverse Tests
+        working-directory: tinyml-tinyverse
+        run: |
+          if [ -d tests ] && find tests -name 'test_*.py' -print -quit | grep -q .; then
+            python -m pytest tests/ -v --tb=short
+          else
+            echo "No tests found in tinyml-tinyverse/tests/ yet -- skipping."
+          fi
+
+      - name: tinyml-modelzoo Tests
+        working-directory: tinyml-modelzoo
+        run: |
+          if [ -d tests ] && find tests -name 'test_*.py' -print -quit | grep -q .; then
+            python -m pytest tests/ -v --tb=short
+          else
+            echo "No tests found in tinyml-modelzoo/tests/ yet -- skipping."
+          fi
+
+      - name: torchmodelopt — Component Tests
+        working-directory: tinyml-modeloptimization/torchmodelopt
+        run: |
+          if [ -d tests ] && find tests -name 'test_*.py' -print -quit | grep -q .; then
+            python -m pytest tests/ -v --tb=short
+          else
+            echo "No tests found in tinyml-modeloptimization/torchmodelopt/tests/ yet -- skipping."
+          fi

--- a/.github/workflows/test-modelmaker.yml
+++ b/.github/workflows/test-modelmaker.yml
@@ -16,6 +16,9 @@ on:
       - 'tinyml-tinyverse/**'
       - 'tinyml-modelzoo/**'
       - 'tinyml-modeloptimization/**'
+      # Without this, a PR that only changes this workflow (like the one
+      # introducing this line) never triggers the very CI it modifies.
+      - '.github/workflows/test-modelmaker.yml'
   workflow_dispatch:  # manual trigger
 
 jobs:


### PR DESCRIPTION
## Problem

Multiple independent peer reviews of PRs opened this session flagged the same gap repeatedly: none of the new regression tests added to `tinyml-tinyverse`, `tinyml-modelzoo`, or `tinyml-modeloptimization/torchmodelopt` actually run in CI. Two compounding problems:

1. `.github/workflows/test-modelmaker.yml`'s `push`/`pull_request` path filters only watched `tinyml-modelmaker/**` — a PR touching only `tinyml-tinyverse`, `tinyml-modelzoo`, or `tinyml-modeloptimization` (which is most of this session's PRs) never triggered the workflow at all.
2. Even when the workflow does run, it only ever executes `tinyml-modelmaker/tests/` (four specific files via named Tier 1/2/3 steps). The other three packages have no test-running step whatsoever.

## Fix

- Restored the `tinyml-tinyverse/**`, `tinyml-modelzoo/**`, and `tinyml-modeloptimization/**` path filters alongside `tinyml-modelmaker/**`, so the workflow actually triggers for PRs touching those packages.
- Added a test step for each of the three previously-uncovered packages, guarded by a `find`-based existence check (not a plain `test -d tests`) since none of these `tests/` directories exist yet on `main` — an empty/missing directory makes pytest exit non-zero ("no tests collected"), which would otherwise fail CI on this package until the first PR adding tests to it merges. The guard lets this land safely now and starts actually running tests the moment any PR adds them.

## Deliberately out of scope

I considered also adding a broader "run everything under `tinyml-modelmaker/tests/`" sweep, since several existing test files there (`test_constants.py`, `test_dataset_utils.py`, `test_nas_support.py`, etc.) aren't wired into any of the three named Tiers and are therefore also never run. I dropped that: it surfaces 17 pre-existing failures unrelated to anything in this session (confirmed even the current, unmodified Tier 1 step alone already fails 2/447 tests locally), which would immediately turn this workflow red on merge. That's a real, separate gap, but out of scope for a fix that should land safely without breaking CI.

## Testing

Verified locally: the `find`-based guard correctly skips `tinyml-tinyverse`, `tinyml-modelzoo`, and `torchmodelopt` on this branch (no test content exists yet on `main`) and would correctly run pytest once a PR adds real test files there. YAML syntax validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)